### PR TITLE
UTF-8 support

### DIFF
--- a/vcard.js
+++ b/vcard.js
@@ -15,7 +15,7 @@ function vCard() {
 			/* now read the data and pass it to getValidationError() */
 			var data;
 			try {
-				data = fs.readFileSync(file, 'ascii');
+				data = fs.readFileSync(file, 'utf-8');
 			} catch (error) {
 				cb(error);
 			}


### PR DESCRIPTION
Switched from ASCII to UTF-8 to retrieve correct names including `Ü ü Ö ö Ä ä` characters